### PR TITLE
bash syntax fixes

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -16,7 +16,6 @@ VERSION=v1.1
 txtred="\e[91;1m"
 txtgrn="\e[1;32m"
 txtgray="\e[0;37m"
-txtblu="\e[0;36m"
 txtrst="\e[0m"
 bldwht='\e[1;37m'
 wht='\e[0;36m'
@@ -1828,11 +1827,11 @@ EOF
 
 
 version() {
-    echo "linux-exploit-suggester "$VERSION", mzet, https://z-labs.eu, March 2019"
+    echo "linux-exploit-suggester ${VERSION}, mzet, https://z-labs.eu, March 2019"
 }
 
 usage() {
-    echo "LES ver. $VERSION (https://github.com/mzet-/linux-exploit-suggester) by @_mzet_"
+    echo "LES ver. ${VERSION} (https://github.com/mzet-/linux-exploit-suggester) by @_mzet_"
     echo
     echo "Usage: linux-exploit-suggester.sh [OPTIONS]"
     echo
@@ -1907,7 +1906,7 @@ getPkgList() {
             OS="mageia"
         # pacman package listing file
         elif [ "$(grep -E '\ [0-9]+\.' "$pkglist_file" | head -1)" ]; then
-            PKG_LIST=$(cat "$pkglist_file" | awk '{print $1"-"$2}')
+            PKG_LIST=$(awk '{print $1"-"$2}' "$pkglist_file")
             OS="arch"
         # file not recognized - skipping
         else
@@ -1931,7 +1930,7 @@ getPkgList() {
 # from: https://stackoverflow.com/questions/4023830/how-compare-two-strings-in-dot-separated-version-format-in-bash
 verComparision() {
 
-    if [[ $1 == $2 ]]
+    if [[ $1 == "$2" ]]
     then
         return 0
     fi
@@ -1970,7 +1969,7 @@ doVersionComparision() {
     local reqRelation="$2"
     local currentVersion="$3"
 
-    verComparision $currentVersion $reqVersion
+    verComparision "${currentVersion}" "${reqVersion}"
     case $? in
         0) currentRelation='=';;
         1) currentRelation='>';;
@@ -1978,17 +1977,17 @@ doVersionComparision() {
     esac
 
     if [ "$reqRelation" == "=" ]; then
-        [ $currentRelation == "=" ] && return 0
+        [ "$currentRelation" == "=" ] && return 0
     elif [ "$reqRelation" == ">" ]; then
-        [ $currentRelation == ">" ] && return 0
+        [ "$currentRelation" == ">" ] && return 0
     elif [ "$reqRelation" == "<" ]; then
-        [ $currentRelation == "<" ] && return 0
+        [ "$currentRelation" == "<" ] && return 0
     elif [ "$reqRelation" == ">=" ]; then
-        [ $currentRelation == "=" ] && return 0
-        [ $currentRelation == ">" ] && return 0
+        [ "$currentRelation" == "=" ] && return 0
+        [ "$currentRelation" == ">" ] && return 0
     elif [ "$reqRelation" == "<=" ]; then
-        [ $currentRelation == "=" ] && return 0
-        [ $currentRelation == "<" ] && return 0
+        [ "$currentRelation" == "=" ] && return 0
+        [ "$currentRelation" == "<" ] && return 0
     fi
 }
 
@@ -2014,7 +2013,7 @@ checkRequirement() {
     if [[ "$IN" =~ ^pkg=.*$ ]]; then
 
         # always true for Linux OS
-        [ ${pkgName} == "linux-kernel" ] && return 0
+        [ "${pkgName}" == "linux-kernel" ] && return 0
 
         # verify if package is present 
         pkg=$(echo "$PKG_LIST" | grep -E -i "^$pkgName-[0-9]+" | head -1)
@@ -2025,14 +2024,14 @@ checkRequirement() {
     elif [[ "$IN" =~ ^ver.*$ ]]; then
         version="${IN//[^0-9.]/}"
         rest="${IN#ver}"
-        operator=${rest%$version}
+        operator="${rest%$version}"
 
         if [ "$pkgName" == "linux-kernel" -o "$opt_checksec_mode" == "true" ]; then
 
             # for --cvelist-file mode skip kernel version comparision
             [ "$opt_cvelist_file" = "true" ] && return 0
 
-            doVersionComparision $version $operator $KERNEL && return 0
+            doVersionComparision "$version" "$operator" "$KERNEL" && return 0
         else
             # extract package version and check if requiremnt is true
             pkg=$(echo "$PKG_LIST" | grep -E -i "^$pkgName-[0-9]+" | head -1)
@@ -2047,7 +2046,7 @@ checkRequirement() {
             #echo "operator: $operator"
             #echo "required version: $version"
             #echo
-            doVersionComparision $version $operator $pkgVersion && return 0
+            doVersionComparision "$version" "$operator" "$pkgVersion" && return 0
         fi
     elif [[ "$IN" =~ ^x86_64$ ]] && [ "$ARCH" == "x86_64" -o "$ARCH" == "" ]; then
         return 0
@@ -2060,7 +2059,7 @@ checkRequirement() {
 
         # if kernel config IS available:
         if [ -n "$KCONFIG" ]; then
-            if $KCONFIG | grep -E -qi $IN; then
+            if $KCONFIG | grep -E -qi "$IN"; then
                 return 0;
             # required option wasn't found, exploit is not applicable
             else
@@ -2078,9 +2077,9 @@ checkRequirement() {
         sysctlCondition="${IN:7}"
 
         # extract sysctl entry, relation sign and required value
-        if echo $sysctlCondition | grep -qi "!="; then
+        if echo "$sysctlCondition" | grep -qi "!="; then
             sign="!="
-        elif echo $sysctlCondition | grep -qi "=="; then
+        elif echo "$sysctlCondition" | grep -qi "=="; then
             sign="=="
         else
             exitWithErrMsg "Wrong sysctl condition. There is syntax error in your features DB. Aborting."
@@ -2098,7 +2097,7 @@ checkRequirement() {
         [ -z "$curVal" ] && return 0
 
         # compare & return result
-        compareValues $curVal $val $sign && return 0
+        compareValues "$curVal" "$val" "$sign" && return 0
 
     elif [[ "$IN" =~ ^cmd:.*$ ]]; then
 
@@ -2118,8 +2117,8 @@ getKernelConfig() {
 
     if [ -f /proc/config.gz ] ; then
         KCONFIG="zcat /proc/config.gz"
-    elif [ -f /boot/config-`uname -r` ] ; then
-        KCONFIG="cat /boot/config-`uname -r`"
+    elif [ -f "/boot/config-$(uname -r)" ] ; then
+        KCONFIG="cat /boot/config-$(uname -r)"
     elif [ -f "${KBUILD_OUTPUT:-/usr/src/linux}"/.config ] ; then
         KCONFIG="cat ${KBUILD_OUTPUT:-/usr/src/linux}/.config"
     else
@@ -2171,7 +2170,7 @@ for FEATURE in "${FEATURES[@]}"; do
 		# find CONFIG_ name (if present) for current feature (only for display purposes)
 		if [ -z "$CONFIG" ]; then
 			config=$(echo "$REQ" | grep "CONFIG_")
-			[ -n "$config" ] && CONFIG="($(echo $REQ | cut -d'=' -f1))"
+			[ -n "$config" ] && CONFIG="($(echo ${REQ} | cut -d'=' -f1))"
 		fi
 
         if (checkRequirement "$REQ"); then
@@ -2206,7 +2205,7 @@ for FEATURE in "${FEATURES[@]}"; do
     feature=$(echo "$FEATURE" | grep "feature: " | cut -d' ' -f 2-)
 
     if [ -n "$cmdStdout" ]; then
-        if [ $cmdStdout -eq 0 ]; then
+        if [ "$cmdStdout" -eq 0 ]; then
             state="[ ${txtred}Set to $cmdStdout${txtrst} ]"
 			cmdStdout=""
         else
@@ -2235,10 +2234,10 @@ for FEATURE in "${FEATURES[@]}"; do
 
 	if [ -z "$KCONFIG" -a "$ENABLE_REQS_NUM" = 0 ]; then
 	    state=$unknown
-    elif [ $AVAILABLE_PASSED_REQ -eq $AVAILABLE_REQS_NUM -a $ENABLE_PASSED_REQ -eq $ENABLE_REQS_NUM ]; then
-        state=$enabled
+    elif [ "$AVAILABLE_PASSED_REQ" -eq "$AVAILABLE_REQS_NUM" -a "$ENABLE_PASSED_REQ" -eq "$ENABLE_REQS_NUM" ]; then
+        state="$enabled"
     else
-        state=$disabled
+        state="$disabled"
 	fi
 
     fi
@@ -2527,7 +2526,7 @@ for EXP in "${EXPLOITS[@]}" "${EXPLOITS_USERSPACE[@]}"; do
             #echo "CVE: $cve"
 
             # check if it's on CVELIST_FILE list, if no move to next exploit
-            [ ! $(cat "$CVELIST_FILE" | grep -E "$cve") ] && continue
+            [ ! "$(grep -E "$cve" "$CVELIST_FILE")" ] && continue
         fi
 
         # process tags and highlight those that match current OS (only for deb|ubuntu|RHEL and if we know distro version - direct mode)
@@ -2554,7 +2553,7 @@ for EXP in "${EXPLOITS[@]}" "${EXPLOITS_USERSPACE[@]}"; do
                     # get name (kernel or package name) and version of kernel/pkg if provided:
                     tag_pkg=$(echo "$tag_distro_num_all" | cut -d'{' -f 2 | tr -d '}' | cut -d':' -f 1)
                     tag_pkg_num=""
-                    [ $(echo "$tag_distro_num_all" | grep '{') ] && tag_pkg_num=$(echo "$tag_distro_num_all" | cut -d'{' -f 2 | tr -d '}' | cut -d':' -f 2)
+                    [ "$(echo "$tag_distro_num_all" | grep '{')" ] && tag_pkg_num=$(echo "$tag_distro_num_all" | cut -d'{' -f 2 | tr -d '}' | cut -d':' -f 2)
 
                     #[ -n "$tag_pkg_num" ] && echo "tag_pkg_num: $tag_pkg_num; kernel: $KERNEL_ALL"
 
@@ -2564,7 +2563,7 @@ for EXP in "${EXPLOITS[@]}" "${EXPLOITS_USERSPACE[@]}"; do
 
                     # kernel version provided, check for match:
                     elif [ -n "$tag_pkg_num" -a "$tag_pkg" = "kernel" ]; then
-                        if [ $(echo "$KERNEL_ALL" | grep -E "${tag_pkg_num}") ]; then
+                        if [ "$(echo "$KERNEL_ALL" | grep -E "${tag_pkg_num}")" ]; then
                             # kernel version matched - bold highlight
                             TAG="${yellow}[ ${TAG} ]${txtrst}"
 
@@ -2639,7 +2638,7 @@ for EXP_TEMP in "${SORTED_EXPLOITS[@]}"; do
 
 	if [ -n "$analysis_url" ]; then
         details="$analysis_url"
-	elif $(echo "$src_url" | grep -q 'www.exploit-db.com'); then
+	elif echo "$src_url" | grep -q 'www.exploit-db.com'; then
         details="https://www.exploit-db.com/exploits/$EXPLOIT_DB/"
 	elif [[ "$src_url" =~ ^.*tgz|tar.gz|zip$ && -n "$EXPLOIT_DB" ]]; then
         details="https://www.exploit-db.com/exploits/$EXPLOIT_DB/"


### PR DESCRIPTION
remove unset variable
fix quotes to prevent glob matching
grep -q instead of [ -n ... ]
file as arg for awk instead of cat file | awk
replace `...` with proper command substitution