### PR TITLE
Update analysis-url for CVE-2021-3490

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -909,7 +909,7 @@ Name: ${txtgrn}[CVE-2021-3490]${txtrst} eBPF ALU32 bounds tracking for bitwise o
 Reqs: pkg=linux-kernel,ver>=5.7,ver<5.12,CONFIG_BPF_SYSCALL=y,sysctl:kernel.unprivileged_bpf_disabled!=1
 Tags: ubuntu=20.04{kernel:5.8.0-(25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52)-*},ubuntu=21.04{kernel:5.11.0-16-*}
 Rank: 5
-analysis-url: https://www.graplsecurity.com/post/kernel-pwning-with-ebpf-a-love-story
+analysis-url: https://chompie.rip/Blog+Posts/Kernel+Pwning+with+eBPF+-+a+Love+Story
 src-url: https://codeload.github.com/chompie1337/Linux_LPE_eBPF_CVE-2021-3490/zip/main
 Comments: CONFIG_BPF_SYSCALL needs to be set && kernel.unprivileged_bpf_disabled != 1
 author: chompie1337


### PR DESCRIPTION
Looks like the blog post for CVE-2021-3490 has moved, with no redirect in place.